### PR TITLE
feat: ASR使用相对路径

### DIFF
--- a/SocketServer.py
+++ b/SocketServer.py
@@ -77,7 +77,7 @@ class Server():
         }
 
         # PARAFORMER
-        self.paraformer = ASRService.ASRService('../DL_Server/ASR/resources/config.yaml')
+        self.paraformer = ASRService.ASRService('./ASR/resources/config.yaml')
 
         # CHAT GPT
         self.chat_gpt = GPTService.GPTService(args)


### PR DESCRIPTION
项目clone后，因采用项目名作为工程目录名，与原目录名称不同，导致路径问题。